### PR TITLE
Changing toDataURL default quality

### DIFF
--- a/background.js
+++ b/background.js
@@ -46,7 +46,7 @@ function saveAsType(img, type, tabId) {
 	var context = canvas.getContext('2d');
 	var mimeType = 'image/'+(type ==  'jpg' ? 'jpeg' : type);
 	context.drawImage(img, 0, 0);
-	var dataurl =  canvas.toDataURL(mimeType);
+	var dataurl =  canvas.toDataURL(mimeType, 0.98);
 	var filename = getSuggestedFilename(img.src, type);
 	download(dataurl, filename, tabId);
 }


### PR DESCRIPTION
By default jpeg/webp quality is set to 0.92 when saving from canvas.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL

(0.98 is just a compromise between size and quality for my personal need; feel free to not merge)